### PR TITLE
Refactor scripts for unified style

### DIFF
--- a/scripts/analysis.tcl
+++ b/scripts/analysis.tcl
@@ -1,4 +1,5 @@
 #!/usr/bin/env tclsh
+
 proc getFrameRange {filename} {
     set fh [open $filename "r"]
     set line [gets $fh]
@@ -123,3 +124,4 @@ set numResidues 20
 computeRg $totalFrames $numResidues "rg.txt"
 
 exit
+

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -4,3 +4,4 @@ USER="jcarde7"
 LOCAL_PROJECT_DIR="/home/admin/es"
 HPC="mike"
 HPC_PROJECT_DIR="/work/jcarde7/es"
+

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source=./config.sh
 
 source "$(dirname "$0")/config.sh"
 
@@ -9,26 +10,26 @@ NAMD_DIR="$BASE_DIR/NAMD_2.14_Linux-x86_64-multicore"
 POLYMERS_DIR="$BASE_DIR/polymers"
 NAME_FILE="$SCRIPT_DIR/names.txt"
 
-
 create_polymer() (
     local sequence="$1"
 
-    max_number=0
+    local max_number=0
     for dir in "$POLYMERS_DIR"/J*; do
         [ -d "$dir" ] || continue
+        local basename
         basename=$(basename "$dir")
         if [[ $basename =~ ^J([0-9]+)$ ]]; then
-            number=${BASH_REMATCH[1]}
+            local number=${BASH_REMATCH[1]}
             (( number > max_number )) && max_number=$number
         fi
     done
-    next_number=$((max_number + 1))
-    POLYMER_NAME="J${next_number}"
-    POLYMER_DIR="$POLYMERS_DIR/$POLYMER_NAME"
+    local next_number=$((max_number + 1))
+    local POLYMER_NAME="J${next_number}"
+    local POLYMER_DIR="$POLYMERS_DIR/$POLYMER_NAME"
 
     mkdir -p "$POLYMER_DIR"
     cp -r "$COPY_DIR"/* "$POLYMER_DIR"
-    cd "$POLYMER_DIR/copy"
+    cd "$POLYMER_DIR/copy" || exit
     if [ -n "$sequence" ]; then
         python3 "$SCRIPT_DIR/update_modifybond.py" "$sequence"
     else
@@ -36,26 +37,28 @@ create_polymer() (
     fi
     python3 modifybond.py
     cp output.pdb topology ../relax
-    cd ../relax
+    cd ../relax || exit
     cp relaxcopy/* .
     "$NAMD_DIR/psfgen" relaxmonomer.pgn
     "$NAMD_DIR/namd2" relax.conf
     vmd -dispdev text -e "$SCRIPT_DIR/save_relax.tcl"
     cp relax.pdb system.dcd ../
-    cd ..
+    cd .. || exit
     cp copy/* .
     python3 "$SCRIPT_DIR/update_mix.py"
     packmol < mix.txt
+    # shellcheck source=extract.sh
     source extract.sh
     "$NAMD_DIR/psfgen" newmonomer.pgn
     vmd -dispdev text -e "$SCRIPT_DIR/save_single_polymer.tcl"
     cp single_polymer.pdb topology 20sim
-    cd 20sim
+    cd 20sim || exit
     cp 20copy/* .
     python3 20_polymers.py
     packmol < pack.txt
     python3 "$SCRIPT_DIR/update_20.py"
     packmol < 20_mix.txt
+    # shellcheck source=20_extract.sh
     source 20_extract.sh
     "$NAMD_DIR/psfgen" 20_newmonomer.pgn
     echo "$POLYMER_NAME" >> "$NAME_FILE"
@@ -64,25 +67,23 @@ create_polymer() (
 main() {
     if [ "$#" -ne 1 ]; then
         echo "Usage: $0 (number of polymers) or $0 (polymer sequences .txt)"
-        exit
+        exit 1
     fi
 
-    > "$NAME_FILE"
+    : > "$NAME_FILE"
 
     if [[ $1 =~ ^[0-9]+$ ]]; then
-        number=$1
-        for (( i = 0; i < number; i++ )); do
+        local number=$1
+        for ((i = 0; i < number; i++)); do
             create_polymer
         done
-
     else
-        sequences=$1
-
+        local sequences=$1
         if [ ! -f "$sequences" ]; then
             echo "$sequences NOT FOUND"
-            exit
+            exit 1
         fi
-        
+
         mapfile -t sequences_array < "$sequences"
         for sequence in "${sequences_array[@]}"; do
             create_polymer "$sequence"

--- a/scripts/queue.sh
+++ b/scripts/queue.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
+# shellcheck source=./config.sh
 
 source "$(dirname "$0")/config.sh"
 
 check_gpu() {
     local job_count
-    job_count=$(
-        ssh "${USER}@mike.hpc.lsu.edu" \
-            'squeue -u '"${USER}"' -h | grep gpu | wc -l'
-    )
+    job_count=$(ssh "${USER}@mike.hpc.lsu.edu" 'squeue -u '"${USER}"' -h | grep gpu | wc -l')
     if [ "$job_count" -lt 4 ]; then
         return 0
     else
@@ -17,10 +15,7 @@ check_gpu() {
 
 check_gpu4() {
     local job_count
-    job_count=$(
-        ssh "${USER}@qbd.loni.org" \
-            'squeue -u '"${USER}"' -h | grep gpu4 | wc -l'
-    )
+    job_count=$(ssh "${USER}@qbd.loni.org" 'squeue -u '"${USER}"' -h | grep gpu4 | wc -l')
     if [ "$job_count" -lt 4 ]; then
         return 0
     else
@@ -30,10 +25,7 @@ check_gpu4() {
 
 check_gpu2() {
     local job_count
-    job_count=$(
-        ssh "${USER}@qbd.loni.org" \
-            'squeue -u '"${USER}"' -h | grep gpu2 | wc -l'
-    )
+    job_count=$(ssh "${USER}@qbd.loni.org" 'squeue -u '"${USER}"' -h | grep gpu2 | wc -l')
     if [ "$job_count" -lt 4 ]; then
         return 0
     else
@@ -65,4 +57,4 @@ main() {
     esac
 }
 
-main
+main "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source=./config.sh
 
 source "$(dirname "$0")/config.sh"
 
@@ -10,39 +11,39 @@ POLYMERS_DIR="$HPC_PROJECT_DIR/polymers"
 
 generate_script() {
     mapfile -t polymer_names < "$NAME_FILE"
-    simulations=${#polymer_names[@]}
+    local simulations=${#polymer_names[@]}
 
     case "$HPC" in
         mike)
-            tasks=4
-            cores=16
-            gres="gpu:4"
-            partition="gpu"
-            account="hpc_hpc_tyw_01"
+            local tasks=4
+            local cores=16
+            local gres="gpu:4"
+            local partition="gpu"
+            local account="hpc_hpc_tyw_01"
             ;;
         loni)
             if [ "$simulations" -eq 4 ]; then
-                tasks=4
-                cores=16
-                gres="gpu:4"
-                partition="gpu4"
-                account="loni_poly_surf"
+                local tasks=4
+                local cores=16
+                local gres="gpu:4"
+                local partition="gpu4"
+                local account="loni_poly_surf"
             elif [ "$simulations" -eq 2 ]; then
-                tasks=2
-                cores=32
-                gres="gpu:2"
-                partition="gpu2"
-                account="loni_poly_surf"
+                local tasks=2
+                local cores=32
+                local gres="gpu:2"
+                local partition="gpu2"
+                local account="loni_poly_surf"
             else
-                exit
+                exit 1
             fi
             ;;
         *)
-            exit
+            exit 1
             ;;
     esac
 
-    cat << EOF > "$SUBMIT_SCRIPT"
+    cat <<EOF_INNER >"$SUBMIT_SCRIPT"
 #!/bin/bash
 #SBATCH -N 1
 #SBATCH -n $tasks
@@ -54,18 +55,18 @@ generate_script() {
 #SBATCH -o /dev/null
 
 module load cuda
-EOF
+EOF_INNER
 
     for poly_name in "${polymer_names[@]}"; do
-        cat << EOF >> "$SUBMIT_SCRIPT"
-srun --ntasks=1 --gres=gpu:1 --cpus-per-task=$cores \\
-     "$NAMD_DIR/namd2" \\
-     +p16 "$POLYMERS_DIR/${poly_name}/20sim/20_waterbox.conf" \\
-     > "$POLYMERS_DIR/${poly_name}/20sim/output.log" &
-EOF
+        cat <<EOF_INNER >>"$SUBMIT_SCRIPT"
+srun --ntasks=1 --gres=gpu:1 --cpus-per-task=$cores \
+    "$NAMD_DIR/namd2" \
+    +p16 "$POLYMERS_DIR/${poly_name}/20sim/20_waterbox.conf" \
+    > "$POLYMERS_DIR/${poly_name}/20sim/output.log" &
+EOF_INNER
     done
-    
-    echo -e "\nwait" >> "$SUBMIT_SCRIPT"
+
+    echo -e "\nwait" >>"$SUBMIT_SCRIPT"
 }
 
 submit() {
@@ -81,10 +82,11 @@ submit() {
 
 main() {
     if [ ! -f "$NAME_FILE" ]; then
-        exit
+        exit 0
     fi
     generate_script
-    #submit
+    # submit
     rm "$NAME_FILE"
 }
-main
+
+main "$@"

--- a/scripts/save_relax.tcl
+++ b/scripts/save_relax.tcl
@@ -1,8 +1,8 @@
 mol new relaxafterpgn.psf
-mol addfile relaxafterpgn.pdb waitfor all  ;
+mol addfile relaxafterpgn.pdb waitfor all
 
 set trajectory_file "system.dcd"
-mol addfile $trajectory_file type dcd waitfor all  ;
+mol addfile $trajectory_file type dcd waitfor all
 
 set num_frames [molinfo top get numframes]
 if {$num_frames == 0} {
@@ -16,11 +16,12 @@ if {![llength [$all_atoms list]]} {
     exit
 }
 
-$all_atoms set chain X  ;
+$all_atoms set chain X
 
-animate goto [expr $num_frames - 1]  ;
-set last_frame [expr $num_frames - 1]
+animate goto [expr {$num_frames - 1}]
+set last_frame [expr {$num_frames - 1}]
 
 animate write pdb relax.pdb beg $last_frame end $last_frame sel $all_atoms
 
 exit
+

--- a/scripts/save_single_polymer.tcl
+++ b/scripts/save_single_polymer.tcl
@@ -1,8 +1,8 @@
 mol new interfaceafterpgn.psf
-mol addfile interfaceafterpgn.pdb waitfor all  ;
+mol addfile interfaceafterpgn.pdb waitfor all
 
 set trajectory_file "system.dcd"
-mol addfile $trajectory_file type dcd waitfor all  ;
+mol addfile $trajectory_file type dcd waitfor all
 
 set num_frames [molinfo top get numframes]
 if {$num_frames == 0} {
@@ -18,13 +18,14 @@ if {![llength [$lig_atoms list]]} {
 
 $lig_atoms set chain A
 
-mol representation VDW  ;
-mol selection "resname LIG"  ;
-mol addrep top  ;
+mol representation VDW
+mol selection "resname LIG"
+mol addrep top
 
-animate goto [expr $num_frames - 1]  ;
-set last_frame [expr $num_frames - 1]
+animate goto [expr {$num_frames - 1}]
+set last_frame [expr {$num_frames - 1}]
 
-$lig_atoms writepdb single_polymer.pdb  ;
+$lig_atoms writepdb single_polymer.pdb
 
 exit
+

--- a/scripts/short.py
+++ b/scripts/short.py
@@ -2,10 +2,14 @@
 import os
 import pandas as pd
 
-script_dir   = os.path.dirname(__file__)
-analysis_csv = os.path.abspath(os.path.join(script_dir, "..", "data", "analysis.csv"))
-df           = pd.read_csv(analysis_csv)
-cols         = [0, 1, 2, 74, 75, 146, 217, 618, 619]
-df_selected  = df.iloc[:, cols]
-short_csv    = os.path.abspath(os.path.join(script_dir, "..", "data", "short.csv"))
+script_dir = os.path.dirname(__file__)
+analysis_csv = os.path.abspath(
+    os.path.join(script_dir, "..", "data", "analysis.csv")
+)
+df = pd.read_csv(analysis_csv)
+cols = [0, 1, 2, 74, 75, 146, 217, 618, 619]
+df_selected = df.iloc[:, cols]
+short_csv = os.path.abspath(
+    os.path.join(script_dir, "..", "data", "short.csv")
+)
 df_selected.to_csv(short_csv, index=False)

--- a/scripts/update_20.py
+++ b/scripts/update_20.py
@@ -1,8 +1,8 @@
 def update_pdb_coordinates_in_place(pdb_file, coord_file):
-    with open(coord_file, 'r') as coord:
+    with open(coord_file, "r") as coord:
         new_coords = [line.strip().split() for line in coord.readlines()]
 
-    with open(pdb_file, 'r') as pdb:
+    with open(pdb_file, "r") as pdb:
         lines = pdb.readlines()
 
     updated_lines = []
@@ -21,13 +21,12 @@ def update_pdb_coordinates_in_place(pdb_file, coord_file):
         else:
             updated_lines.append(line)
 
-    with open(pdb_file, 'w') as pdb:
+    with open(pdb_file, "w") as pdb:
         pdb.writelines(updated_lines)
 
     print(f"PDB file '{pdb_file}' has been updated with new coordinates.")
 
-update_pdb_coordinates_in_place(
-    pdb_file="20_polymers.pdb",
-    coord_file="20_coordinate.txt"
-)
 
+update_pdb_coordinates_in_place(
+    pdb_file="20_polymers.pdb", coord_file="20_coordinate.txt"
+)

--- a/scripts/update_mix.py
+++ b/scripts/update_mix.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 pdb_file = "output.pdb"
@@ -29,7 +28,9 @@ try:
         previous_line = ""
         for line in lines:
 
-            if previous_line.strip() == "end atoms" and re.match(r"^\s*atoms\s+\d+", line):
+            if previous_line.strip() == "end atoms" and re.match(
+                r"^\s*atoms\s+\d+", line
+            ):
                 file.write(f"atoms {max_atom}\n")
             else:
                 file.write(line)
@@ -60,4 +61,3 @@ except FileNotFoundError:
 except PermissionError:
     print(f"Error: Insufficient permissions to write to {extract_script}.")
     exit(1)
-

--- a/scripts/update_modifybond.py
+++ b/scripts/update_modifybond.py
@@ -2,8 +2,9 @@ import sys
 import ast
 import random
 
+
 def generate_random_input_list():
-    chain_types = ['E', 'S']
+    chain_types = ["E", "S"]
     sidechain_length_range = list(range(0, 10))
     backbone_length = random.randint(10, 15)
     input_list = []
@@ -13,8 +14,9 @@ def generate_random_input_list():
         input_list.append((i, f"{chain_type}{sidechain_length}"))
     return input_list
 
+
 def update_modifybond_script(file_path, new_input_list):
-    with open(file_path, 'r') as file:
+    with open(file_path, "r") as file:
         lines = file.readlines()
 
     updated_lines = []
@@ -24,10 +26,11 @@ def update_modifybond_script(file_path, new_input_list):
         else:
             updated_lines.append(line)
 
-    with open(file_path, 'w') as file:
+    with open(file_path, "w") as file:
         file.writelines(updated_lines)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if len(sys.argv) > 1:
         try:
             input_list = ast.literal_eval(sys.argv[1])

--- a/scripts/workflow.sh
+++ b/scripts/workflow.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e
+# shellcheck source=./config.sh
+
 source "$(dirname "$0")/config.sh"
 
 main() {
+    local simulations
     simulations=$(./queue.sh | tail -n 1)
 
     if [ "$simulations" -gt 0 ]; then
@@ -13,4 +16,4 @@ main() {
     fi
 }
 
-main
+main "$@"


### PR DESCRIPTION
## Summary
- streamline Python imports and formatting
- rewrite bash scripts with consistent structure
- clean up TCL scripts and remove stray text
- ensure style checks pass

## Testing
- `pytest -q`
- `flake8 scripts/*.py`
- `shellcheck scripts/config.sh scripts/generate.sh scripts/queue.sh scripts/run.sh scripts/workflow.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d409879148323b3f9738527eb003f